### PR TITLE
Don't poll again after success.

### DIFF
--- a/driver/src/io_backend/ext/xaie_linux.c
+++ b/driver/src/io_backend/ext/xaie_linux.c
@@ -489,8 +489,7 @@ static AieRC XAie_LinuxIO_MaskPoll(void *IOInst, u64 RegOff, u32 Mask, u32 Value
 	while (Count > 0U) {
 		XAie_LinuxIO_Read32(IOInst, RegOff, &RegVal);
 		if((RegVal & Mask) == Value) {
-			Ret = XAIE_OK;
-			break;
+			return XAIE_OK;
 		}
 		usleep(MinTimeOutUs);
 		Count--;
@@ -498,8 +497,7 @@ static AieRC XAie_LinuxIO_MaskPoll(void *IOInst, u64 RegOff, u32 Mask, u32 Value
 
 	/* Check for the break from timed-out loop */
 	XAie_LinuxIO_Read32(IOInst, RegOff, &RegVal);
-	if((Ret == XAIE_ERR) && ((RegVal & Mask) ==
-			 Value)) {
+	if((RegVal & Mask) == Value) {
 		Ret = XAIE_OK;
 	}
 


### PR DESCRIPTION
Apply ef3765a6c4ab029f59cf5b22e456b8174457818d to the linux backend. Note that this behavior is functionally critical, since this code is executed in situations where additional reads are not idempotent (e.g., lock acquire and release).