### PR TITLE
Pass pointers as `const` where appropriate 

### DIFF
--- a/driver/src/dma/xaie_dma.c
+++ b/driver/src/dma/xaie_dma.c
@@ -64,7 +64,7 @@
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaDescInit(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
+AieRC XAie_DmaDescInit(const XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
 		XAie_LocType Loc)
 {
 	u8 TileType;
@@ -605,7 +605,7 @@ AieRC XAie_DmaConfigFifoMode(XAie_DmaDesc *DmaDesc, XAie_DmaFifoCounter Counter)
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaGetNumBds(XAie_DevInst *DevInst, XAie_LocType Loc, u8 *NumBds)
+AieRC XAie_DmaGetNumBds(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 *NumBds)
 {
 	const XAie_DmaMod *DmaMod;
 	u8 TileType;
@@ -835,7 +835,7 @@ AieRC XAie_DmaSetInterleaveEnable(XAie_DmaDesc *DmaDesc, u8 DoubleBuff,
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaWriteBd(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
+AieRC XAie_DmaWriteBd(const XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
 		XAie_LocType Loc, u16 BdNum)
 {
 	const XAie_DmaMod *DmaMod;
@@ -876,7 +876,7 @@ AieRC XAie_DmaWriteBd(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaReadBd(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
+AieRC XAie_DmaReadBd(const XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
 		XAie_LocType Loc, u16 BdNum)
 {
 	const XAie_DmaMod *DmaMod;
@@ -922,7 +922,7 @@ AieRC XAie_DmaReadBd(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
 * @note		Returns error for SHIMNOC tiles.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelReset(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+AieRC XAie_DmaChannelReset(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir, XAie_DmaChReset Reset)
 {
 	u8 TileType;
@@ -983,7 +983,7 @@ AieRC XAie_DmaChannelReset(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 * @note		Returns error for SHIMNOC tiles.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelResetAll(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaChannelResetAll(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		XAie_DmaChReset Reset)
 {
 	u8 TileType;
@@ -1044,7 +1044,7 @@ AieRC XAie_DmaChannelResetAll(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note		For AIE Shim Noc Tiles only.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelPauseStream(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaChannelPauseStream(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u8 Pause)
 {
 	u8 TileType;
@@ -1107,7 +1107,7 @@ AieRC XAie_DmaChannelPauseStream(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note		For AIE Shim Noc Tiles only.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelPauseMem(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+AieRC XAie_DmaChannelPauseMem(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir, u8 Pause)
 {
 	u8 TileType;
@@ -1171,7 +1171,7 @@ AieRC XAie_DmaChannelPauseMem(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 *		channel.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelPushBdToQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaChannelPushBdToQueue(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u16 BdNum)
 {
 	AieRC RC;
@@ -1236,7 +1236,7 @@ AieRC XAie_DmaChannelPushBdToQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note		Internal only.
 *
 ******************************************************************************/
-static AieRC _XAie_DmaChannelControl(XAie_DevInst *DevInst, XAie_LocType Loc,
+static AieRC _XAie_DmaChannelControl(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u8 Enable)
 {
 	u8 TileType;
@@ -1290,7 +1290,7 @@ static AieRC _XAie_DmaChannelControl(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelEnable(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+AieRC XAie_DmaChannelEnable(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir)
 {
 	return _XAie_DmaChannelControl(DevInst, Loc, ChNum, Dir, XAIE_ENABLE);
@@ -1311,7 +1311,7 @@ AieRC XAie_DmaChannelEnable(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelDisable(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+AieRC XAie_DmaChannelDisable(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir)
 {
 	return _XAie_DmaChannelControl(DevInst, Loc, ChNum, Dir, XAIE_DISABLE);
@@ -1335,7 +1335,7 @@ AieRC XAie_DmaChannelDisable(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 * If multiple BDs are chained, it's counted as one BD.
 *
 ******************************************************************************/
-AieRC XAie_DmaGetPendingBdCount(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaGetPendingBdCount(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u8 *PendingBd)
 {
 	u8 TileType;
@@ -1383,7 +1383,7 @@ AieRC XAie_DmaGetPendingBdCount(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaGetChannelStatus(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaGetChannelStatus(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u32 *Status)
 {
 	u8 TileType;
@@ -1432,7 +1432,7 @@ AieRC XAie_DmaGetChannelStatus(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note		This API in context of TXN flow will be a yeilded poll wait.
 *
 ******************************************************************************/
-AieRC XAie_DmaWaitForDone(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+AieRC XAie_DmaWaitForDone(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir, u32 TimeOutUs)
 {
 	u8 TileType;
@@ -1485,7 +1485,7 @@ AieRC XAie_DmaWaitForDone(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 * @note		This API in context of TXN flow will be a busy poll wait.
 *
 ******************************************************************************/
-AieRC XAie_DmaWaitForDoneBusy(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+AieRC XAie_DmaWaitForDoneBusy(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir, u32 TimeOutUs)
 {
 	u8 TileType;
@@ -1539,7 +1539,7 @@ AieRC XAie_DmaWaitForDoneBusy(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 * @note     This API in context of TXN flow will be a yeilded poll wait.
 *
 ******************************************************************************/
-AieRC XAie_DmaWaitForBdTaskQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaWaitForBdTaskQueue(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u32 TimeOutUs)
 {
 	u8 TileType;
@@ -1598,7 +1598,7 @@ AieRC XAie_DmaWaitForBdTaskQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note     This API in context of TXN flow will be a busy poll wait.
 *
 ******************************************************************************/
-AieRC XAie_DmaWaitForBdTaskQueueBusy(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaWaitForBdTaskQueueBusy(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u32 TimeOutUs)
 {
 	u8 TileType;
@@ -1654,7 +1654,7 @@ AieRC XAie_DmaWaitForBdTaskQueueBusy(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaGetMaxQueueSize(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaGetMaxQueueSize(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 *QueueSize)
 {
 	u8 TileType;
@@ -1697,7 +1697,7 @@ AieRC XAie_DmaGetMaxQueueSize(XAie_DevInst *DevInst, XAie_LocType Loc,
 *		This API doesn't support out of order.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelSetStartQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
+AieRC XAie_DmaChannelSetStartQueue(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u16 BdNum, u32 RepeatCount,
 		u8 EnTokenIssue)
 {
@@ -1725,7 +1725,7 @@ AieRC XAie_DmaChannelSetStartQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
 * @note		This feature is not supported for AIE.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelSetStartQueueGeneric(XAie_DevInst *DevInst,
+AieRC XAie_DmaChannelSetStartQueueGeneric(const XAie_DevInst *DevInst,
 		XAie_LocType Loc, u8 ChNum, XAie_DmaDirection Dir,
 		XAie_DmaQueueDesc *DmaQueueDesc)
 {
@@ -1829,7 +1829,7 @@ AieRC XAie_DmaChannelSetStartQueueGeneric(XAie_DevInst *DevInst,
 * 		no effect on AIE.
 *
 ******************************************************************************/
-AieRC XAie_DmaChannelDescInit(XAie_DevInst *DevInst,
+AieRC XAie_DmaChannelDescInit(const XAie_DevInst *DevInst,
 		XAie_DmaChannelDesc *DmaChannelDesc, XAie_LocType Loc)
 {
 	u8 TileType;
@@ -2037,7 +2037,7 @@ AieRC XAie_DmaChannelSetFoTMode(XAie_DmaChannelDesc *DmaChannelDesc,
 * @note		This API works only for AIE-ML and has no effect on AIE.
 *
 ******************************************************************************/
-AieRC XAie_DmaWriteChannel(XAie_DevInst *DevInst,
+AieRC XAie_DmaWriteChannel(const XAie_DevInst *DevInst,
 		XAie_DmaChannelDesc *DmaChannelDesc, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir)
 {
@@ -2303,7 +2303,7 @@ AieRC XAie_DmaTlastDisable(XAie_DmaDesc *DmaDesc)
 * @note		Returns 0 if the Buffer Descriptor Valid bit is 0.
 *
 ******************************************************************************/
-AieRC XAie_DmaGetBdLen(XAie_DevInst *DevInst, XAie_LocType Loc, u32 *Len,
+AieRC XAie_DmaGetBdLen(const XAie_DevInst *DevInst, XAie_LocType Loc, u32 *Len,
 		u16 BdNum)
 {
 	u8 TileType;
@@ -2375,7 +2375,7 @@ AieRC XAie_DmaGetBdLen(XAie_DevInst *DevInst, XAie_LocType Loc, u32 *Len,
 * @note		This API accesses the hardware directly and does not operate
 *		on software descriptor.
 ******************************************************************************/
-AieRC XAie_DmaUpdateBdLen(XAie_DevInst *DevInst, XAie_LocType Loc, u32 Len,
+AieRC XAie_DmaUpdateBdLen(const XAie_DevInst *DevInst, XAie_LocType Loc, u32 Len,
 		u16 BdNum)
 {
 	const XAie_DmaMod *DmaMod;
@@ -2422,7 +2422,7 @@ AieRC XAie_DmaUpdateBdLen(XAie_DevInst *DevInst, XAie_LocType Loc, u32 Len,
 * @note		This API accesses the hardware directly and does not operate
 *		on software descriptor.
 ******************************************************************************/
-AieRC XAie_DmaUpdateBdAddr(XAie_DevInst *DevInst, XAie_LocType Loc, u64 Addr,
+AieRC XAie_DmaUpdateBdAddr(const XAie_DevInst *DevInst, XAie_LocType Loc, u64 Addr,
 		u16 BdNum)
 {
 	const XAie_DmaMod *DmaMod;
@@ -2472,7 +2472,7 @@ AieRC XAie_DmaUpdateBdAddr(XAie_DevInst *DevInst, XAie_LocType Loc, u64 Addr,
 * @note		None.
 *
 ******************************************************************************/
-AieRC XAie_DmaSetPadValue(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+AieRC XAie_DmaSetPadValue(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		u32 PadValue)
 {
 	const XAie_DmaMod *DmaMod;

--- a/driver/src/dma/xaie_dma.h
+++ b/driver/src/dma/xaie_dma.h
@@ -73,7 +73,7 @@ typedef enum {
 
 XAIE_AIG_EXPORT AieRC XAie_DmaLockControl(XAie_DmaDesc *DmaDesc, XAie_Lock Acq,
 		XAie_Lock Rel, u8 AcqEn, u8 RelEn);
-XAIE_AIG_EXPORT AieRC XAie_DmaDescInit(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
+XAIE_AIG_EXPORT AieRC XAie_DmaDescInit(const XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
 		XAie_LocType Loc);
 XAIE_AIG_EXPORT AieRC XAie_DmaSetLock(XAie_DmaDesc *DmaDesc, XAie_Lock Acq, XAie_Lock Rel);
 XAIE_AIG_EXPORT AieRC XAie_DmaSetPkt(XAie_DmaDesc *DmaDesc, XAie_Packet Pkt);
@@ -91,7 +91,7 @@ XAIE_AIG_EXPORT AieRC XAie_DmaSetPadding(XAie_DmaDesc *DmaDesc, XAie_DmaPadTenso
 XAIE_AIG_EXPORT AieRC XAie_DmaEnableCompression(XAie_DmaDesc *DmaDesc);
 XAIE_AIG_EXPORT AieRC XAie_DmaConfigFifoMode(XAie_DmaDesc *DmaDesc,
 		XAie_DmaFifoCounter Counter);
-XAIE_AIG_EXPORT AieRC XAie_DmaGetNumBds(XAie_DevInst *DevInst, XAie_LocType Loc, u8 *NumBds);
+XAIE_AIG_EXPORT AieRC XAie_DmaGetNumBds(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 *NumBds);
 XAIE_AIG_EXPORT AieRC XAie_DmaSetNextBd(XAie_DmaDesc *DmaDesc, u16 NextBd, u8 EnableNextBd);
 XAIE_AIG_EXPORT AieRC XAie_DmaEnableBd(XAie_DmaDesc *DmaDesc);
 XAIE_AIG_EXPORT AieRC XAie_DmaDisableBd(XAie_DmaDesc *DmaDesc);
@@ -99,43 +99,43 @@ XAIE_AIG_EXPORT AieRC XAie_DmaSetAxi(XAie_DmaDesc *DmaDesc, u8 Smid, u8 BurstLen
 		u8 Cache, u8 Secure);
 XAIE_AIG_EXPORT AieRC XAie_DmaSetInterleaveEnable(XAie_DmaDesc *DmaDesc, u8 DoubleBuff,
 		u8 IntrleaveCount, u16 IntrleaveCurr);
-XAIE_AIG_EXPORT AieRC XAie_DmaWriteBd(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
+XAIE_AIG_EXPORT AieRC XAie_DmaWriteBd(const XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
 		XAie_LocType Loc, u16 BdNum);
-XAIE_AIG_EXPORT AieRC XAie_DmaReadBd(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
+XAIE_AIG_EXPORT AieRC XAie_DmaReadBd(const XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
 		XAie_LocType Loc, u16 BdNum);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelResetAll(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelResetAll(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		XAie_DmaChReset Reset);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelReset(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelReset(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, XAie_DmaChReset Reset);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelPauseStream(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelPauseStream(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u8 Pause);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelPauseMem(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelPauseMem(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir, u8 Pause);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelPushBdToQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelPushBdToQueue(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u16 BdNum);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelEnable(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelEnable(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelDisable(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelDisable(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir);
-XAIE_AIG_EXPORT AieRC XAie_DmaWaitForDone(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+XAIE_AIG_EXPORT AieRC XAie_DmaWaitForDone(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir, u32 TimeOutUs);
-XAIE_AIG_EXPORT AieRC XAie_DmaWaitForDoneBusy(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+XAIE_AIG_EXPORT AieRC XAie_DmaWaitForDoneBusy(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		XAie_DmaDirection Dir, u32 TimeOutUs);
-XAIE_AIG_EXPORT AieRC XAie_DmaWaitForBdTaskQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaWaitForBdTaskQueue(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u32 TimeOutUs);
-XAIE_AIG_EXPORT AieRC XAie_DmaWaitForBdTaskQueueBusy(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaWaitForBdTaskQueueBusy(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u32 TimeOutUs);
-XAIE_AIG_EXPORT AieRC XAie_DmaGetPendingBdCount(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaGetPendingBdCount(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u8 *PendingBd);
-XAIE_AIG_EXPORT AieRC XAie_DmaGetMaxQueueSize(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaGetMaxQueueSize(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 *QueueSize);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelSetStartQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelSetStartQueue(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u16 BdNum, u32 RepeatCount,
 		u8 EnTokenIssue);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelSetStartQueueGeneric(XAie_DevInst *DevInst,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelSetStartQueueGeneric(const XAie_DevInst *DevInst,
 		XAie_LocType Loc, u8 ChNum, XAie_DmaDirection Dir,
 		XAie_DmaQueueDesc *DmaQueueDesc);
-XAIE_AIG_EXPORT AieRC XAie_DmaWriteChannel(XAie_DevInst *DevInst,
+XAIE_AIG_EXPORT AieRC XAie_DmaWriteChannel(const XAie_DevInst *DevInst,
 		XAie_DmaChannelDesc *DmaChannelDesc, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir);
 XAIE_AIG_EXPORT AieRC XAie_DmaChannelSetFoTMode(XAie_DmaChannelDesc *DmaChannelDesc,
@@ -146,21 +146,21 @@ XAIE_AIG_EXPORT AieRC XAie_DmaChannelEnOutofOrder(XAie_DmaChannelDesc *DmaChanne
 		u8 EnOutofOrder);
 XAIE_AIG_EXPORT AieRC XAie_DmaChannelEnCompression(XAie_DmaChannelDesc *DmaChannelDesc,
 		u8 EnCompression);
-XAIE_AIG_EXPORT AieRC XAie_DmaChannelDescInit(XAie_DevInst *DevInst,
+XAIE_AIG_EXPORT AieRC XAie_DmaChannelDescInit(const XAie_DevInst *DevInst,
 		XAie_DmaChannelDesc *DmaChannelDesc, XAie_LocType Loc);
 XAIE_AIG_EXPORT AieRC XAie_DmaSetZeroPadding(XAie_DmaDesc *DmaDesc, u8 Dim,
 		XAie_DmaZeroPaddingPos Pos, u8 NumZeros);
 XAIE_AIG_EXPORT AieRC XAie_DmaTlastEnable(XAie_DmaDesc *DmaDesc);
 XAIE_AIG_EXPORT AieRC XAie_DmaTlastDisable(XAie_DmaDesc *DmaDesc);
-XAIE_AIG_EXPORT AieRC XAie_DmaGetBdLen(XAie_DevInst *DevInst, XAie_LocType Loc, u32 *Len,
+XAIE_AIG_EXPORT AieRC XAie_DmaGetBdLen(const XAie_DevInst *DevInst, XAie_LocType Loc, u32 *Len,
 		u16 BdNum);
-XAIE_AIG_EXPORT AieRC XAie_DmaUpdateBdLen(XAie_DevInst *DevInst, XAie_LocType Loc, u32 Len,
+XAIE_AIG_EXPORT AieRC XAie_DmaUpdateBdLen(const XAie_DevInst *DevInst, XAie_LocType Loc, u32 Len,
 		u16 BdNum);
-XAIE_AIG_EXPORT AieRC XAie_DmaUpdateBdAddr(XAie_DevInst *DevInst, XAie_LocType Loc, u64 Addr,
+XAIE_AIG_EXPORT AieRC XAie_DmaUpdateBdAddr(const XAie_DevInst *DevInst, XAie_LocType Loc, u64 Addr,
 		u16 BdNum);
-XAIE_AIG_EXPORT AieRC XAie_DmaSetPadValue(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+XAIE_AIG_EXPORT AieRC XAie_DmaSetPadValue(const XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
 		u32 PadValue);
-XAIE_AIG_EXPORT AieRC XAie_DmaGetChannelStatus(XAie_DevInst *DevInst, XAie_LocType Loc,
+XAIE_AIG_EXPORT AieRC XAie_DmaGetChannelStatus(const XAie_DevInst *DevInst, XAie_LocType Loc,
 		u8 ChNum, XAie_DmaDirection Dir, u32 *Status);
 
 #endif		/* end of protection macro */


### PR DESCRIPTION
Please see https://github.com/Xilinx/aie-rt/issues/14. This PR just does a search and replace of `(XAie_DevInst *` with `(const XAie_DevInst *` in 2 files. 