### PR TITLE
cmake: bump minimum required version to 3.5

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.5)
 
 list (APPEND CMAKE_MODULE_PATH
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake"

--- a/fal/CMakeLists.txt
+++ b/fal/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.5)
 
 list (APPEND CMAKE_MODULE_PATH
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake"


### PR DESCRIPTION
CMake 4.0 removed compatibility with cmake_minimum_required(VERSION < 3.5), so configuring fal/ and driver/ now fails with:

  CMake Error at CMakeLists.txt:7 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

Bump the declared minimum in both top-level CMakeLists.txt files to 3.5 so the package configures with CMake >= 4 (e.g. CMake 4.2 in Ubuntu 26.04). 3.5 is older than the CMake shipped in any currently supported LTS, so this does not regress older build environments.

Closes: #23 