### PR TITLE
Provide a CDO interface and support initial I/O backend selection

### DIFF
--- a/driver/src/global/xaiegbl.c
+++ b/driver/src/global/xaiegbl.c
@@ -85,6 +85,46 @@ extern const XAie_DeviceOps Aie2PDevOps;
 /*****************************************************************************/
 /**
 *
+* This API selects the I/O backend used during device initialization.
+*
+* @param	DevInst: Global AIE device instance pointer.
+* @param	Backend: Backend I/O type to initialize.
+*
+* @return	XAIE_OK on success and error code on failure.
+*
+* @note		This function must be called before XAie_CfgInitialize(). If it
+*		is not called, the compile-time default backend is used.
+*
+*******************************************************************************/
+AieRC XAie_SetupBackendConfig(XAie_DevInst *DevInst,
+		XAie_BackendType Backend)
+{
+	const XAie_Backend *BackendPtr;
+
+	if (DevInst == XAIE_NULL || DevInst->IsReady != 0U) {
+		XAIE_ERROR("Invalid Device instance to set backend config.\n");
+		return XAIE_INVALID_DEVICE;
+	}
+
+	if ((u32)Backend >= (u32)XAIE_IO_BACKEND_MAX) {
+		XAIE_ERROR("Invalid backend request.\n");
+		return XAIE_INVALID_ARGS;
+	}
+
+	BackendPtr = _XAie_GetBackendPtr(Backend);
+	if (BackendPtr == XAIE_NULL) {
+		XAIE_ERROR("Requested backend is unavailable.\n");
+		return XAIE_INVALID_ARGS;
+	}
+
+	DevInst->Backend = BackendPtr;
+
+	return XAIE_OK;
+}
+
+/*****************************************************************************/
+/**
+*
 * This API is to set up AI engine partition instance location and size.
 *
 * @param	Inst: Pointer of AI engine partition instance
@@ -425,6 +465,7 @@ AieRC XAie_Finish(XAie_DevInst *DevInst)
 	}
 
 	DevInst->IsReady = 0;
+	DevInst->Backend = XAIE_NULL;
 
 	return XAIE_OK;
 }

--- a/driver/src/global/xaiegbl.h
+++ b/driver/src/global/xaiegbl.h
@@ -544,6 +544,8 @@ typedef struct {
 
 
 /**************************** Function prototypes ***************************/
+XAIE_AIG_EXPORT AieRC XAie_SetupBackendConfig(XAie_DevInst *DevInst,
+		XAie_BackendType Backend);
 XAIE_AIG_EXPORT AieRC XAie_SetupPartitionConfig(XAie_DevInst *DevInst,
 		u64 PartBaseAddr, u8 PartStartCol, u8 PartNumCols);
 XAIE_AIG_EXPORT AieRC XAie_CfgInitialize(XAie_DevInst *InstPtr, XAie_Config *ConfigPtr);

--- a/driver/src/io_backend/ext/cdo_rts.h
+++ b/driver/src/io_backend/ext/cdo_rts.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef CDO_RTS_H
+#define CDO_RTS_H
+
+#include <stdint.h>
+
+void cdo_Write32(uint64_t Addr, uint32_t Data);
+void cdo_MaskWrite32(uint64_t Addr, uint32_t Mask, uint32_t Data);
+void cdo_MaskPoll(uint64_t Addr, uint32_t Mask, uint32_t ExpectedValue,
+		uint32_t TimeoutInMs);
+void cdo_BlockWrite32(uint64_t Addr, uint32_t *Data, uint32_t Size);
+void cdo_BlockSet32(uint64_t Addr, uint32_t Data, uint32_t Size);
+
+#endif /* CDO_RTS_H */

--- a/driver/src/io_backend/xaie_io.c
+++ b/driver/src/io_backend/xaie_io.c
@@ -124,7 +124,11 @@ static const XAie_Backend *IOBackend[XAIE_IO_BACKEND_MAX] =
 AieRC XAie_IOInit(XAie_DevInst *DevInst)
 {
 	AieRC RC;
-	const XAie_Backend *Backend = IOBackend[XAIE_DEFAULT_BACKEND];
+	const XAie_Backend *Backend = DevInst->Backend;
+
+	if (Backend == XAIE_NULL) {
+		Backend = IOBackend[XAIE_DEFAULT_BACKEND];
+	}
 
 	RC = Backend->Ops.Init(DevInst);
 	if(RC != XAIE_OK) {


### PR DESCRIPTION
### Provenance

MLIR-AIE is currently undergoing an infrastructure modernization. Previously, we had been using an AIE-RT commit from 2024 and mutating it to our needs. As the project has matured, that is no longer appropriate. This PR, and one that will follow shortly, are intended to introduce the needed functionality with minimal disruption.

### Why

MLIR-AIE needs to initialize directly with the CDO backend when multiple backends are compiled. `XAie_SetIOBackend()` cannot do this because it only switches an already initialized device.

### Changes

* Add `XAie_SetupBackendConfig()` to select a compiled-in backend before `XAie_CfgInitialize()`.
* Use the existing `XAie_DevInst::Backend` field and retain `XAIE_DEFAULT_BACKEND` when no selection is made.
* Reject invalid, unavailable, and post-initialization selections.
* Clear the selected backend in `XAie_Finish()`.
* Add the CDO runtime declarations used by `xaie_cdo.c`.

This does not change the `XAie_Config` layout or existing caller behavior.

### Testing

* Built with the CDO, simulation, and debug backends enabled together.
* Covered explicit, default, invalid, post-initialization, finish, and reinitialization behavior.
* Built MLIR-AIE on Windows and passed NPU execution with CDO selected before initialization.