### PR TITLE
Expose transaction command-to-operation mapping

### DIFF
--- a/driver/src/common/xaie_txn.c
+++ b/driver/src/common/xaie_txn.c
@@ -1616,547 +1616,122 @@ bool _XAie_TxnReSerialized(XAie_DevInst *DevInst, u8* SrcTxn, u8** ReserTxn)
 * @note		Internal only.
 *
 ******************************************************************************/
-u8* _XAie_TxnExportSerialized(XAie_DevInst *DevInst, u8 NumConsumers,
-		u32 Flags)
+static void _XAie_TxnMapFlushBlockWrites(const XAie_TxnInst *TxnInst,
+		u32 Begin, u32 End, XAie_TxnCmdOpMap *Map, u32 *NextOp)
 {
-	const XAie_Backend *Backend = DevInst->Backend;
-	XAie_TxnInst *TmpInst = NULL;
-	u8 *TxnPtr = NULL;
-	u8 *TxnBasePtr = NULL;
-	u32 BuffSize = 0U, NumOps = 0, PatchCmdCount = 0,BWBuffSize = 0;
-	u32 LoadSeqCount = 0;
-	u64 RegOffLastBlockWrite = 0;
-	u8 FirstBlockwriteProcessed = 0;
-	u32* BlockwriteBuffer = NULL;
-	u8* LoadSeqCountPtr = NULL;
-	u32 LoadSeqCountOffset = 0;
+	u32 BlockWriteOp = *NextOp;
 
-	u32 AllocatedBuffSize = XAIE_DEFAULT_TXN_BUFFER_SIZE;
-	u32 BWBuffAllocatedSize = XAIE_DEFAULT_TXN_BUFFER_SIZE;
-	(void)NumConsumers;
-	(void)Flags;
-
-	TmpInst = _XAie_GetTxnInst(DevInst, Backend->Ops.GetTid());
-	if(TmpInst == NULL) {
-		XAIE_ERROR("Failed to get the correct transaction instance "
-				"from internal list\n");
-		return NULL;
+	(*NextOp)++;
+	for(u32 I = Begin; I < End; I++) {
+		if(TxnInst->CmdBuf[I].Opcode == XAIE_IO_BLOCKWRITE) {
+			Map->CmdToOp[I] = BlockWriteOp;
+		}
 	}
 
-	BlockwriteBuffer = calloc(1,BWBuffAllocatedSize);
-	if(BlockwriteBuffer == NULL) {
-		XAIE_ERROR("BlockWrite Buffer Calloc failed\n");
-		return NULL;
-	}
-
-	TxnPtr = calloc(1,AllocatedBuffSize);
-	if(TxnPtr == NULL) {
-		XAIE_ERROR("TxnPtr Calloc failed\n");
-		free(BlockwriteBuffer);
-		return NULL;
-	}
-
-	// Saved base pointer to avoid backward pointer arithmetic
-	TxnBasePtr = TxnPtr;
-	_XAie_CreateTxnHeader(DevInst, (XAie_TxnHeader *)(uintptr_t)TxnPtr);
-	BuffSize += (u32)sizeof(XAie_TxnHeader);
-	TxnPtr += sizeof(XAie_TxnHeader);
-	XAIE_DBG("number of cmd %d\n", TmpInst->NumCmds);
-
-	for(u32 i = 0U; i < TmpInst->NumCmds; i++) {
-		NumOps++;
-		XAie_TxnCmd *Cmd = &TmpInst->CmdBuf[i];
-
-		if( (DevInst->PmLoadingActive == 1) && (Cmd->Opcode != XAIE_IO_LOAD_PM_START) && (Cmd->Opcode != XAIE_IO_LOAD_PM_END_INTERNAL))
-		{
-			LoadSeqCount++;
-		}
-
-		if( (Cmd->Opcode != XAIE_IO_BLOCKWRITE) &&
-		    (Cmd->Opcode != XAIE_IO_CUSTOM_OP_DDR_PATCH) &&
-		    (FirstBlockwriteProcessed != 0) )
-		{
-			XAie_BlockWrite32Hdr *Hdr = (XAie_BlockWrite32Hdr*)(uintptr_t)BlockwriteBuffer;
-			while((BuffSize + Hdr->Size) > AllocatedBuffSize) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-				(AllocatedBuffSize) * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			BuffSize += Hdr->Size;
-			TxnPtr += _XAie_AppendBWToTxnBuff(BlockwriteBuffer,TxnPtr,PatchCmdCount);
-			PatchCmdCount = 0;
-			FirstBlockwriteProcessed = 0;
-		}
-		if ((Cmd->Opcode == XAIE_IO_WRITE) && (Cmd->Mask == 0U)) {
-			while((BuffSize + sizeof(XAie_Write32Hdr)) >
-					AllocatedBuffSize) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL){
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendWrite32(DevInst, Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_Write32Hdr);
-			BuffSize += (u32)sizeof(XAie_Write32Hdr);
-			continue;
-		}
-		else if ((Cmd->Opcode == XAIE_IO_WRITE) && ((Cmd->Mask)!=0U)) {
-			while((BuffSize + sizeof(XAie_MaskWrite32Hdr)) >
-					AllocatedBuffSize) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendMaskWrite32(DevInst, Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_MaskWrite32Hdr);
-			BuffSize += (u32)sizeof(XAie_MaskWrite32Hdr);
-			continue;
-		}
-		else if (Cmd->Opcode == XAIE_IO_MASKPOLL) {
-			while((BuffSize + sizeof(XAie_MaskPoll32Hdr)) >
-					AllocatedBuffSize) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendMaskPoll32(DevInst, Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_MaskPoll32Hdr);
-			BuffSize += (u32)sizeof(XAie_MaskPoll32Hdr);
-			continue;
-		}
-		else if (Cmd->Opcode == XAIE_IO_MASKPOLL_BUSY) {
-			while((BuffSize + sizeof(XAie_MaskPoll32Hdr)) >
-					AllocatedBuffSize) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendMaskPollBusy32(DevInst, Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_MaskPoll32Hdr);
-			BuffSize += (u32)sizeof(XAie_MaskPoll32Hdr);
-			continue;
-		}
-		else if (Cmd->Opcode == XAIE_IO_BLOCKWRITE) {
-			/**
-			 * In case of Block Write and Block Set, it is possible
-			 * that the new allocated buffer size may not be sufficient.
-			 * In that case we should keep reallocating till the new
-			 * buffer size if big enough to hold existing + current opcode.
-			 */
-			BWBuffSize = ((XAie_BlockWrite32Hdr*)(uintptr_t)BlockwriteBuffer)->Size;
-			if(FirstBlockwriteProcessed != 0)
-			{
-			 	if ( Cmd->RegOff != RegOffLastBlockWrite)
-			 	{
-					while((BuffSize + BWBuffSize) > AllocatedBuffSize) {
-						u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						(AllocatedBuffSize) * 2U, BuffSize);
-						if(TmpPtr == NULL) {
-							XAIE_ERROR("TxnPtr realloc failed\n");
-							free(BlockwriteBuffer);
-							free(TxnBasePtr);
-							return NULL;
-						}
-						TxnBasePtr = TmpPtr;
-						AllocatedBuffSize *= 2U;
-						TxnPtr = TxnBasePtr + BuffSize;
-					}
-					BuffSize += BWBuffSize;
-					TxnPtr += _XAie_AppendBWToTxnBuff(BlockwriteBuffer,TxnPtr,PatchCmdCount);
-					PatchCmdCount = 0;
-					FirstBlockwriteProcessed = 0;
-				}
-				else
-				{
-					NumOps--;
-
-					/**
-					 * Load Sequence Count should be reduced only if there is an active
-					 * PM Loading else do nothing.
-					 **/
-					if (DevInst->PmLoadingActive == 1) {
-						LoadSeqCount--;
-					}
-				}
-			} else {
-				/**
-				 *  When BW Buffer is empty which is represented by FirstBlockwriteProcessed == 0
-				 *  BWBuffSize should be initialized to size of XAie_BlockWrite32Hdr struct in bytes.
-				 *  Since the Cmd->Size field of Cmd from TmpInst->CmdBuf only considers payload size.
-				 */
-				BWBuffSize = sizeof(XAie_BlockWrite32Hdr);
-			}
-
-			while( (Cmd->Size * 4) + BWBuffSize > BWBuffAllocatedSize)
-			{
-				u32 *TmpBWPtr = (u32*) (uintptr_t) ( _XAie_ReallocTxnBuf_MemInit((u8 *)BlockwriteBuffer,
-									( BWBuffAllocatedSize + BWBuffAllocatedSize), BWBuffSize) );
-				if(TmpBWPtr == NULL) {
-					XAIE_ERROR("BlockWrite Buffer Realloc Failed\n");
-					free(BlockwriteBuffer);
-					// To free Txn Buffer successfully we need to use the start pointer not current pointer
-					free(TxnBasePtr);
-					return NULL;
-				}
-				BlockwriteBuffer = TmpBWPtr;
-				BWBuffAllocatedSize *= 2U;
-			}
-			RegOffLastBlockWrite = (u64) ( Cmd->RegOff + (Cmd->Size*4) );
-			_XAie_AppendBWToBlockwriteBuff(DevInst, Cmd, FirstBlockwriteProcessed, BlockwriteBuffer);
-			FirstBlockwriteProcessed = 1;
-		}
-		else if (Cmd->Opcode == XAIE_IO_BLOCKSET) {
-			/**
-			 * In case of Block Write and Block Set, it is possible
-			 * that the new allocated buffer size may not be sufficient
-			 * In that case we should keep reallocating till the new
-			 * buffer size if big enough to hold existing + current opcode.
-			 *
-			 * Blockset gets converted to blockwrite. so check for
-			 * blockwrite size
-			 */
-			while((BuffSize + sizeof(XAie_BlockWrite32Hdr) +
-						Cmd->Size * sizeof(u32)) >
-					AllocatedBuffSize) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendBlockSet32(DevInst, Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_BlockWrite32Hdr) +
-				Cmd->Size * sizeof(u32);
-			BuffSize += (u32)sizeof(XAie_BlockWrite32Hdr) +
-				Cmd->Size * (u32)sizeof(u32);
-			continue;
-		}
-		else if(Cmd->Opcode == XAIE_IO_NOOP)
-		{
-			while( (BuffSize + sizeof(XAie_NoOpHdr)) >
-					AllocatedBuffSize ) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendNoOp(Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_NoOpHdr);
-			BuffSize += (u32)sizeof(XAie_NoOpHdr);
-			continue;
-		}
-		else if(Cmd->Opcode == XAIE_IO_PREEMPT)
-		{
-			while( (BuffSize + sizeof(XAie_PreemptHdr)) >
-					AllocatedBuffSize ) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendPreempt(Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_PreemptHdr);
-			BuffSize += (u32)sizeof(XAie_PreemptHdr);
-			continue;
-		}
-		else if(Cmd->Opcode == XAIE_IO_LOADPDI)
-		{
-			while( (BuffSize + sizeof(XAie_LoadPdiHdr)) >
-					AllocatedBuffSize ) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendLoadPdi(Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_LoadPdiHdr);
-			BuffSize += (u32)sizeof(XAie_LoadPdiHdr);
-			continue;
-		}
-		else if(Cmd->Opcode == XAIE_IO_LOAD_PM_START)
-		{
-			while( (BuffSize + sizeof(XAie_PmLoadHdr)) >
-					AllocatedBuffSize ) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			LoadSeqCountPtr = _XAie_AppendPmLoad(Cmd, TxnPtr, &LoadSeqCountOffset);
-			LoadSeqCountOffset += BuffSize;
-			TxnPtr += sizeof(XAie_PmLoadHdr);
-			BuffSize += (u32)sizeof(XAie_PmLoadHdr);
-			DevInst->PmLoadingActive = 1;
-			continue;
-		}
-		else if (Cmd->Opcode == XAIE_IO_LOAD_PM_END_INTERNAL)
-		{
-			// Check if LoadSeqCountPtr needs to be updated due to realloc of TXN Ptr.
-			if ((LoadSeqCountOffset != 0) && (LoadSeqCountPtr != (TxnBasePtr + LoadSeqCountOffset))) {
-				LoadSeqCountPtr = TxnBasePtr + LoadSeqCountOffset;
-			}
-
-			if((LoadSeqCount != 0) && (LoadSeqCountPtr != NULL))
-			{
-				*LoadSeqCountPtr = LoadSeqCount & 0xFF;
-				*(LoadSeqCountPtr + 1) = (LoadSeqCount & 0xFF00) >> 8;
-				*(LoadSeqCountPtr + 2) = (LoadSeqCount & 0xFF0000) >> 16;
-			}
-			else if (LoadSeqCountPtr == NULL)
-			{
-				XAIE_ERROR("LoadSeqCountPtr is equal to NULL\n");
-				free(BlockwriteBuffer);
-				// To free Txn Buffer successfully we need to use the start pointer not current pointer
-				free(TxnBasePtr);
-				return NULL;
-			}
-			LoadSeqCount = 0;
-			NumOps--;
-			DevInst->PmLoadingActive = 0;
-			continue;
-		}
-		else if(Cmd->Opcode == XAIE_IO_CREATE_SCRATCHPAD)
-		{
-			while( (BuffSize + sizeof(XAie_CreateScratchpadHdr)) >
-					AllocatedBuffSize ) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendCreateScratchpad(Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_CreateScratchpadHdr);
-			BuffSize += (u32)sizeof(XAie_CreateScratchpadHdr);
-			continue;
-		}
-		else if(Cmd->Opcode == XAIE_IO_UPDATE_STATE_TABLE)
-		{
-			while((BuffSize + sizeof(XAie_UpdateStateHdr)) >
-					AllocatedBuffSize ) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendUpdateState(Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_UpdateStateHdr);
-			BuffSize += (u32)sizeof(XAie_UpdateStateHdr);
-			continue;
-		}
-		else if(Cmd->Opcode == XAIE_IO_UPDATE_REG)
-		{
-			/* Check for 16KB boundary crossing and add padding if needed */
-			TxnPtr = _XAie_HandleTxnCmd16KBBoundary(TxnPtr, &BuffSize,
-								&AllocatedBuffSize, (u32)sizeof(XAie_UpdateRegHdr),
-								BlockwriteBuffer, &NumOps);
-			if (TxnPtr == NULL) {
-				return NULL;
-			}
-			while((BuffSize + sizeof(XAie_UpdateRegHdr)) >
-					AllocatedBuffSize ) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendUpdateReg(Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_UpdateRegHdr);
-			BuffSize += (u32)sizeof(XAie_UpdateRegHdr);
-			continue;
-		}
-		else if(Cmd->Opcode == XAIE_IO_UPDATE_SCRATCH)
-		{
-			while( (BuffSize + sizeof(XAie_UpdateScratchHdr)) >
-					AllocatedBuffSize ) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendUpdateScratch(Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_UpdateScratchHdr);
-			BuffSize += (u32)sizeof(XAie_UpdateScratchHdr);
-			continue;
-		}
-		else if (Cmd->Opcode >= XAIE_IO_CUSTOM_OP_TCT) {
-
-			if(Cmd->Opcode == XAIE_IO_CUSTOM_OP_DDR_PATCH)
-			{
-				++PatchCmdCount;
-			}
-			if (TX_DUMP_ENABLE) {
-				TxnCmdDump(Cmd);
-			}
-
-			XAIE_DBG("Size of the CustomOp Hdr being exported: %u bytes\n", sizeof(XAie_CustomOpHdr));
-
-			while((BuffSize + sizeof(XAie_CustomOpHdr) +
-						Cmd->Size) > AllocatedBuffSize) {
-				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						AllocatedBuffSize * 2U, BuffSize);
-				if(TmpPtr == NULL) {
-					XAIE_ERROR("TxnPtr realloc failed\n");
-					free(BlockwriteBuffer);
-					free(TxnBasePtr);
-					return NULL;
-				}
-				TxnBasePtr = TmpPtr;
-				AllocatedBuffSize *= 2U;
-				TxnPtr = TxnBasePtr + BuffSize;
-			}
-			_XAie_AppendCustomOp(Cmd, TxnPtr);
-			TxnPtr += sizeof(XAie_CustomOpHdr) +
-				Cmd->Size * sizeof(u8);
-			BuffSize += (u32)sizeof(XAie_CustomOpHdr) +
-				Cmd->Size * (u32)sizeof(u8);
-			continue;
+	for(u32 I = Begin; I < End; I++) {
+		if(TxnInst->CmdBuf[I].Opcode == XAIE_IO_CUSTOM_OP_DDR_PATCH) {
+			Map->CmdToOp[I] = (*NextOp)++;
 		}
 	}
-	if(FirstBlockwriteProcessed != 0)
-	{	
-		XAie_BlockWrite32Hdr *Hdr = (XAie_BlockWrite32Hdr*)(uintptr_t)BlockwriteBuffer;
-		while((BuffSize + Hdr->Size) > AllocatedBuffSize) {
-			u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
-						(AllocatedBuffSize) * 2U, BuffSize);
-			if(TmpPtr == NULL) {
-				XAIE_ERROR("TxnPtr realloc failed\n");
-				free(BlockwriteBuffer);
-				free(TxnBasePtr);
-				return NULL;
-			}
-			TxnBasePtr = TmpPtr;
-			AllocatedBuffSize *= 2U;
-			TxnPtr = TxnBasePtr + BuffSize;
-		}
-		BuffSize += Hdr->Size;
-		TxnPtr += _XAie_AppendBWToTxnBuff(BlockwriteBuffer,TxnPtr,PatchCmdCount);
-	}
-
-	// Free the BlockwriteBuffer
-	free(BlockwriteBuffer);
-
-	u32 four_byte_aligned_BuffSize = ((BuffSize % 4U) != 0U) ? ((BuffSize / 4U + 1U)*4) : BuffSize;
-	XAIE_DBG("Size of the Txn Hdr being exported: %u bytes\n",
-			sizeof(XAie_TxnHeader));
-	XAIE_DBG("Size of the transaction buffer being exported: %u bytes\n",
-			four_byte_aligned_BuffSize);
-	XAIE_DBG("Num of Operations in the transaction buffer: %u\n",
-			TmpInst->NumCmds);
-
-	/* Adjust pointer and reallocate to the right size */
-	u8 *NewPtr = _XAie_ReallocTxnBuf(TxnBasePtr, four_byte_aligned_BuffSize);
-	if(NewPtr == NULL) {
-		XAIE_ERROR("TxnPtr realloc failed\n");
-		free(TxnBasePtr);  /* Free original buffer on failure */
-		return NULL;
-	}
-	TxnBasePtr = NewPtr;
-	((XAie_TxnHeader *)(uintptr_t)TxnBasePtr)->NumOps =  NumOps;
-	((XAie_TxnHeader *)(uintptr_t)TxnBasePtr)->TxnSize =  four_byte_aligned_BuffSize;
-
-	return (u8 *)TxnBasePtr;
 }
+
+#define XAIE_TXN_EXPORT_NAME _XAie_TxnExportSerialized
+#define XAIE_TXN_EXPORT_MAP_PARAMETER
+#define XAIE_TXN_EXPORT_MAP_STATE
+#define XAIE_TXN_EXPORT_MAP_FLUSH_BLOCKWRITES(TxnInst, End) ((void)0)
+#define XAIE_TXN_EXPORT_MAP_COMMAND(Index) ((void)0)
+#define XAIE_TXN_EXPORT_MAP_BLOCKWRITE(TxnInst, Cmd, Index, LastEnd) ((void)0)
+#define XAIE_TXN_EXPORT_MAP_NO_OPERATION(Index) ((void)0)
+#define XAIE_TXN_EXPORT_MAP_BEFORE_UPDATE_REG(NumOps) ((void)0)
+#define XAIE_TXN_EXPORT_MAP_UPDATE_REG(Index, NumOps) ((void)0)
+#define XAIE_TXN_EXPORT_MAP_CUSTOM_COMMAND(Cmd, Index) ((void)0)
+#define XAIE_TXN_EXPORT_MAP_UNHANDLED_COMMAND(Cmd, Index) ((void)0)
+#define XAIE_TXN_EXPORT_MAP_FINALIZE(TxnInst, NumOps, BlockBuf, TxnBuf) ((void)0)
+#include "xaie_txn_export.inc"
+#undef XAIE_TXN_EXPORT_MAP_FINALIZE
+#undef XAIE_TXN_EXPORT_MAP_UNHANDLED_COMMAND
+#undef XAIE_TXN_EXPORT_MAP_CUSTOM_COMMAND
+#undef XAIE_TXN_EXPORT_MAP_UPDATE_REG
+#undef XAIE_TXN_EXPORT_MAP_BEFORE_UPDATE_REG
+#undef XAIE_TXN_EXPORT_MAP_NO_OPERATION
+#undef XAIE_TXN_EXPORT_MAP_BLOCKWRITE
+#undef XAIE_TXN_EXPORT_MAP_COMMAND
+#undef XAIE_TXN_EXPORT_MAP_FLUSH_BLOCKWRITES
+#undef XAIE_TXN_EXPORT_MAP_STATE
+#undef XAIE_TXN_EXPORT_MAP_PARAMETER
+#undef XAIE_TXN_EXPORT_NAME
+
+#define XAIE_TXN_EXPORT_NAME _XAie_TxnExportSerializedWithCmdOpMap
+#define XAIE_TXN_EXPORT_MAP_PARAMETER , XAie_TxnCmdOpMap *Map
+#define XAIE_TXN_EXPORT_MAP_STATE \
+	u32 MapNextOp = 0U; \
+	u32 MapPendingBlockWrite = UINT_MAX; \
+	u32 MapNumOpsBeforeUpdateReg = 0U
+#define XAIE_TXN_EXPORT_MAP_FLUSH_BLOCKWRITES(TxnInst, End) \
+	do { \
+		_XAie_TxnMapFlushBlockWrites((TxnInst), MapPendingBlockWrite, \
+				(End), Map, &MapNextOp); \
+		MapPendingBlockWrite = UINT_MAX; \
+	} while(0)
+#define XAIE_TXN_EXPORT_MAP_COMMAND(Index) \
+	do { Map->CmdToOp[(Index)] = MapNextOp++; } while(0)
+#define XAIE_TXN_EXPORT_MAP_BLOCKWRITE(TxnInst, Cmd, Index, LastEnd) \
+	do { \
+		if(MapPendingBlockWrite == UINT_MAX) { \
+			MapPendingBlockWrite = (Index); \
+		} else if((Cmd)->RegOff != (LastEnd)) { \
+			_XAie_TxnMapFlushBlockWrites((TxnInst), \
+					MapPendingBlockWrite, (Index), Map, &MapNextOp); \
+			MapPendingBlockWrite = (Index); \
+		} \
+	} while(0)
+#define XAIE_TXN_EXPORT_MAP_NO_OPERATION(Index) \
+	do { Map->CmdToOp[(Index)] = XAIE_TXN_CMD_NO_SERIALIZED_OP; } while(0)
+#define XAIE_TXN_EXPORT_MAP_BEFORE_UPDATE_REG(NumOps) \
+	do { MapNumOpsBeforeUpdateReg = (NumOps); } while(0)
+#define XAIE_TXN_EXPORT_MAP_UPDATE_REG(Index, NumOps) \
+	do { \
+		MapNextOp += (NumOps) - MapNumOpsBeforeUpdateReg; \
+		Map->CmdToOp[(Index)] = MapNextOp++; \
+	} while(0)
+#define XAIE_TXN_EXPORT_MAP_CUSTOM_COMMAND(Cmd, Index) \
+	do { \
+		if(((Cmd)->Opcode != XAIE_IO_CUSTOM_OP_DDR_PATCH) || \
+				(MapPendingBlockWrite == UINT_MAX)) { \
+			Map->CmdToOp[(Index)] = MapNextOp++; \
+		} \
+	} while(0)
+#define XAIE_TXN_EXPORT_MAP_UNHANDLED_COMMAND(Cmd, Index) \
+	do { \
+		if((Cmd)->Opcode != XAIE_IO_BLOCKWRITE) { \
+			Map->CmdToOp[(Index)] = XAIE_TXN_CMD_NO_SERIALIZED_OP; \
+		} \
+	} while(0)
+#define XAIE_TXN_EXPORT_MAP_FINALIZE(TxnInst, NumOps, BlockBuf, TxnBuf) \
+	do { \
+		if((MapPendingBlockWrite != UINT_MAX) || \
+				(MapNextOp != (NumOps))) { \
+			XAIE_ERROR("Failed to map transaction commands to serialized operations\n"); \
+			free(BlockBuf); \
+			free(TxnBuf); \
+			return NULL; \
+		} \
+		Map->NumCmds = (TxnInst)->NumCmds; \
+		Map->NumOps = (NumOps); \
+	} while(0)
+#include "xaie_txn_export.inc"
+#undef XAIE_TXN_EXPORT_MAP_FINALIZE
+#undef XAIE_TXN_EXPORT_MAP_UNHANDLED_COMMAND
+#undef XAIE_TXN_EXPORT_MAP_CUSTOM_COMMAND
+#undef XAIE_TXN_EXPORT_MAP_UPDATE_REG
+#undef XAIE_TXN_EXPORT_MAP_BEFORE_UPDATE_REG
+#undef XAIE_TXN_EXPORT_MAP_NO_OPERATION
+#undef XAIE_TXN_EXPORT_MAP_BLOCKWRITE
+#undef XAIE_TXN_EXPORT_MAP_COMMAND
+#undef XAIE_TXN_EXPORT_MAP_FLUSH_BLOCKWRITES
+#undef XAIE_TXN_EXPORT_MAP_STATE
+#undef XAIE_TXN_EXPORT_MAP_PARAMETER
+#undef XAIE_TXN_EXPORT_NAME
 
 static inline void _XAie_AppendBWToBlockwriteBuff_opt(XAie_TxnCmd *Cmd, u8 FirstBlockwriteProcessed, u32* BlockwriteBuffer)
 {
@@ -4193,6 +3768,72 @@ u8* XAie_ExportSerializedTransaction(XAie_DevInst *DevInst,
 	}
 
 	return _XAie_TxnExportSerialized(DevInst, NumConsumers, Flags);
+}
+
+/*****************************************************************************/
+/**
+* Export a serialized transaction and the command-to-operation mapping created
+* by the serializer. Multiple commands can map to one operation when adjacent
+* block writes are coalesced.
+*
+*******************************************************************************/
+u8* XAie_ExportSerializedTransactionWithCmdOpMap(XAie_DevInst *DevInst,
+		u8 NumConsumers, u32 Flags, XAie_TxnCmdOpMap *Map)
+{
+	const XAie_Backend *Backend;
+	XAie_TxnInst *TxnInst;
+	u8 *SerializedTxn;
+
+	if((DevInst == XAIE_NULL) ||
+		(DevInst->IsReady != XAIE_COMPONENT_IS_READY) || (Map == NULL)) {
+		XAIE_ERROR("Invalid arguments\n");
+		return NULL;
+	}
+
+	Map->NumCmds = 0U;
+	Map->NumOps = 0U;
+	Map->CmdToOp = NULL;
+	Backend = DevInst->Backend;
+	TxnInst = _XAie_GetTxnInst(DevInst, Backend->Ops.GetTid());
+	if(TxnInst == NULL) {
+		XAIE_ERROR("Failed to get the correct transaction instance "
+				"from internal list\n");
+		return NULL;
+	}
+
+	if(TxnInst->NumCmds != 0U) {
+		if(TxnInst->NumCmds > (UINT_MAX / (u32)sizeof(u32))) {
+			XAIE_ERROR("Transaction command map is too large\n");
+			return NULL;
+		}
+		Map->CmdToOp = malloc((size_t)TxnInst->NumCmds * sizeof(u32));
+		if(Map->CmdToOp == NULL) {
+			XAIE_ERROR("Failed to allocate transaction command map\n");
+			return NULL;
+		}
+	}
+
+	SerializedTxn = _XAie_TxnExportSerializedWithCmdOpMap(DevInst,
+			NumConsumers, Flags, Map);
+	if(SerializedTxn == NULL) {
+		free(Map->CmdToOp);
+		Map->CmdToOp = NULL;
+		Map->NumCmds = 0U;
+		Map->NumOps = 0U;
+	}
+	return SerializedTxn;
+}
+
+void XAie_FreeTxnCmdOpMap(XAie_TxnCmdOpMap *Map)
+{
+	if(Map == NULL) {
+		return;
+	}
+
+	free(Map->CmdToOp);
+	Map->CmdToOp = NULL;
+	Map->NumCmds = 0U;
+	Map->NumOps = 0U;
 }
 
 /*****************************************************************************/

--- a/driver/src/common/xaie_txn.h
+++ b/driver/src/common/xaie_txn.h
@@ -98,6 +98,19 @@ typedef struct {
 	uint32_t TxnSize;
 } XAie_TxnHeader;
 
+/* Recorded commands that emit no serialized operation map to this value. */
+#define XAIE_TXN_CMD_NO_SERIALIZED_OP ((u32)UINT_MAX)
+
+/*
+ * Serializer-owned result metadata returned to the caller. CmdToOp contains
+ * NumCmds entries and must be released with XAie_FreeTxnCmdOpMap().
+ */
+typedef struct {
+	u32 NumCmds;
+	u32 NumOps;
+	u32 *CmdToOp;
+} XAie_TxnCmdOpMap;
+
 typedef struct {
 	uint8_t Op;
 	uint8_t Col;
@@ -334,6 +347,15 @@ XAIE_AIG_EXPORT AieRC XAie_SubmitTransaction(XAie_DevInst *DevInst, XAie_TxnInst
 XAie_TxnInst* XAie_ExportTransactionInstance(XAie_DevInst *DevInst);
 XAIE_AIG_EXPORT u8* XAie_ExportSerializedTransaction(XAie_DevInst *DevInst,
 		u8 NumConsumers, u32 Flags);
+/*
+ * On success, Map describes the returned serialized transaction. The caller
+ * owns Map->CmdToOp and must release it with XAie_FreeTxnCmdOpMap() before
+ * reusing the same map object.
+ */
+XAIE_AIG_EXPORT u8* XAie_ExportSerializedTransactionWithCmdOpMap(
+		XAie_DevInst *DevInst, u8 NumConsumers, u32 Flags,
+		XAie_TxnCmdOpMap *Map);
+XAIE_AIG_EXPORT void XAie_FreeTxnCmdOpMap(XAie_TxnCmdOpMap *Map);
 XAIE_AIG_EXPORT u8* XAie_ExportSerializedTransaction_opt(XAie_DevInst *DevInst,
 		u8 NumConsumers, u32 Flags);
 XAIE_AIG_EXPORT bool XAie_ReserializeTransaction(XAie_DevInst *DevInst, u8* SrcTxn, u8** ReserTxn);

--- a/driver/src/common/xaie_txn_export.inc
+++ b/driver/src/common/xaie_txn_export.inc
@@ -1,0 +1,570 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef XAIE_TXN_EXPORT_NAME
+#error "XAIE_TXN_EXPORT_NAME must be defined"
+#endif
+
+u8* XAIE_TXN_EXPORT_NAME(XAie_DevInst *DevInst, u8 NumConsumers,
+		u32 Flags XAIE_TXN_EXPORT_MAP_PARAMETER)
+{
+	const XAie_Backend *Backend = DevInst->Backend;
+	XAie_TxnInst *TmpInst = NULL;
+	u8 *TxnPtr = NULL;
+	u8 *TxnBasePtr = NULL;
+	u32 BuffSize = 0U, NumOps = 0, PatchCmdCount = 0,BWBuffSize = 0;
+	u32 LoadSeqCount = 0;
+	u64 RegOffLastBlockWrite = 0;
+	u8 FirstBlockwriteProcessed = 0;
+	u32* BlockwriteBuffer = NULL;
+	u8* LoadSeqCountPtr = NULL;
+	u32 LoadSeqCountOffset = 0;
+	XAIE_TXN_EXPORT_MAP_STATE;
+
+	u32 AllocatedBuffSize = XAIE_DEFAULT_TXN_BUFFER_SIZE;
+	u32 BWBuffAllocatedSize = XAIE_DEFAULT_TXN_BUFFER_SIZE;
+	(void)NumConsumers;
+	(void)Flags;
+
+	TmpInst = _XAie_GetTxnInst(DevInst, Backend->Ops.GetTid());
+	if(TmpInst == NULL) {
+		XAIE_ERROR("Failed to get the correct transaction instance "
+				"from internal list\n");
+		return NULL;
+	}
+
+	BlockwriteBuffer = calloc(1,BWBuffAllocatedSize);
+	if(BlockwriteBuffer == NULL) {
+		XAIE_ERROR("BlockWrite Buffer Calloc failed\n");
+		return NULL;
+	}
+
+	TxnPtr = calloc(1,AllocatedBuffSize);
+	if(TxnPtr == NULL) {
+		XAIE_ERROR("TxnPtr Calloc failed\n");
+		free(BlockwriteBuffer);
+		return NULL;
+	}
+
+	// Saved base pointer to avoid backward pointer arithmetic
+	TxnBasePtr = TxnPtr;
+	_XAie_CreateTxnHeader(DevInst, (XAie_TxnHeader *)(uintptr_t)TxnPtr);
+	BuffSize += (u32)sizeof(XAie_TxnHeader);
+	TxnPtr += sizeof(XAie_TxnHeader);
+	XAIE_DBG("number of cmd %d\n", TmpInst->NumCmds);
+
+	for(u32 i = 0U; i < TmpInst->NumCmds; i++) {
+		NumOps++;
+		XAie_TxnCmd *Cmd = &TmpInst->CmdBuf[i];
+
+		if( (DevInst->PmLoadingActive == 1) && (Cmd->Opcode != XAIE_IO_LOAD_PM_START) && (Cmd->Opcode != XAIE_IO_LOAD_PM_END_INTERNAL))
+		{
+			LoadSeqCount++;
+		}
+
+		if( (Cmd->Opcode != XAIE_IO_BLOCKWRITE) &&
+		    (Cmd->Opcode != XAIE_IO_CUSTOM_OP_DDR_PATCH) &&
+		    (FirstBlockwriteProcessed != 0) )
+		{
+			XAIE_TXN_EXPORT_MAP_FLUSH_BLOCKWRITES(TmpInst, i);
+			XAie_BlockWrite32Hdr *Hdr = (XAie_BlockWrite32Hdr*)(uintptr_t)BlockwriteBuffer;
+			while((BuffSize + Hdr->Size) > AllocatedBuffSize) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+				(AllocatedBuffSize) * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			BuffSize += Hdr->Size;
+			TxnPtr += _XAie_AppendBWToTxnBuff(BlockwriteBuffer,TxnPtr,PatchCmdCount);
+			PatchCmdCount = 0;
+			FirstBlockwriteProcessed = 0;
+		}
+		if ((Cmd->Opcode == XAIE_IO_WRITE) && (Cmd->Mask == 0U)) {
+			while((BuffSize + sizeof(XAie_Write32Hdr)) >
+					AllocatedBuffSize) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL){
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendWrite32(DevInst, Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_Write32Hdr);
+			BuffSize += (u32)sizeof(XAie_Write32Hdr);
+			continue;
+		}
+		else if ((Cmd->Opcode == XAIE_IO_WRITE) && ((Cmd->Mask)!=0U)) {
+			while((BuffSize + sizeof(XAie_MaskWrite32Hdr)) >
+					AllocatedBuffSize) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendMaskWrite32(DevInst, Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_MaskWrite32Hdr);
+			BuffSize += (u32)sizeof(XAie_MaskWrite32Hdr);
+			continue;
+		}
+		else if (Cmd->Opcode == XAIE_IO_MASKPOLL) {
+			while((BuffSize + sizeof(XAie_MaskPoll32Hdr)) >
+					AllocatedBuffSize) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendMaskPoll32(DevInst, Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_MaskPoll32Hdr);
+			BuffSize += (u32)sizeof(XAie_MaskPoll32Hdr);
+			continue;
+		}
+		else if (Cmd->Opcode == XAIE_IO_MASKPOLL_BUSY) {
+			while((BuffSize + sizeof(XAie_MaskPoll32Hdr)) >
+					AllocatedBuffSize) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendMaskPollBusy32(DevInst, Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_MaskPoll32Hdr);
+			BuffSize += (u32)sizeof(XAie_MaskPoll32Hdr);
+			continue;
+		}
+		else if (Cmd->Opcode == XAIE_IO_BLOCKWRITE) {
+			XAIE_TXN_EXPORT_MAP_BLOCKWRITE(TmpInst, Cmd, i, RegOffLastBlockWrite);
+			/**
+			 * In case of Block Write and Block Set, it is possible
+			 * that the new allocated buffer size may not be sufficient.
+			 * In that case we should keep reallocating till the new
+			 * buffer size if big enough to hold existing + current opcode.
+			 */
+			BWBuffSize = ((XAie_BlockWrite32Hdr*)(uintptr_t)BlockwriteBuffer)->Size;
+			if(FirstBlockwriteProcessed != 0)
+			{
+				if ( Cmd->RegOff != RegOffLastBlockWrite)
+				{
+					while((BuffSize + BWBuffSize) > AllocatedBuffSize) {
+						u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						(AllocatedBuffSize) * 2U, BuffSize);
+						if(TmpPtr == NULL) {
+							XAIE_ERROR("TxnPtr realloc failed\n");
+							free(BlockwriteBuffer);
+							free(TxnBasePtr);
+							return NULL;
+						}
+						TxnBasePtr = TmpPtr;
+						AllocatedBuffSize *= 2U;
+						TxnPtr = TxnBasePtr + BuffSize;
+					}
+					BuffSize += BWBuffSize;
+					TxnPtr += _XAie_AppendBWToTxnBuff(BlockwriteBuffer,TxnPtr,PatchCmdCount);
+					PatchCmdCount = 0;
+					FirstBlockwriteProcessed = 0;
+				}
+				else
+				{
+					NumOps--;
+
+					/**
+					 * Load Sequence Count should be reduced only if there is an active
+					 * PM Loading else do nothing.
+					 **/
+					if (DevInst->PmLoadingActive == 1) {
+						LoadSeqCount--;
+					}
+				}
+			} else {
+				/**
+				 *  When BW Buffer is empty which is represented by FirstBlockwriteProcessed == 0
+				 *  BWBuffSize should be initialized to size of XAie_BlockWrite32Hdr struct in bytes.
+				 *  Since the Cmd->Size field of Cmd from TmpInst->CmdBuf only considers payload size.
+				 */
+				BWBuffSize = sizeof(XAie_BlockWrite32Hdr);
+			}
+
+			while( (Cmd->Size * 4) + BWBuffSize > BWBuffAllocatedSize)
+			{
+				u32 *TmpBWPtr = (u32*) (uintptr_t) ( _XAie_ReallocTxnBuf_MemInit((u8 *)BlockwriteBuffer,
+									( BWBuffAllocatedSize + BWBuffAllocatedSize), BWBuffSize) );
+				if(TmpBWPtr == NULL) {
+					XAIE_ERROR("BlockWrite Buffer Realloc Failed\n");
+					free(BlockwriteBuffer);
+					// To free Txn Buffer successfully we need to use the start pointer not current pointer
+					free(TxnBasePtr);
+					return NULL;
+				}
+				BlockwriteBuffer = TmpBWPtr;
+				BWBuffAllocatedSize *= 2U;
+			}
+			RegOffLastBlockWrite = (u64) ( Cmd->RegOff + (Cmd->Size*4) );
+			_XAie_AppendBWToBlockwriteBuff(DevInst, Cmd, FirstBlockwriteProcessed, BlockwriteBuffer);
+			FirstBlockwriteProcessed = 1;
+		}
+		else if (Cmd->Opcode == XAIE_IO_BLOCKSET) {
+			/**
+			 * In case of Block Write and Block Set, it is possible
+			 * that the new allocated buffer size may not be sufficient
+			 * In that case we should keep reallocating till the new
+			 * buffer size if big enough to hold existing + current opcode.
+			 *
+			 * Blockset gets converted to blockwrite. so check for
+			 * blockwrite size
+			 */
+			while((BuffSize + sizeof(XAie_BlockWrite32Hdr) +
+						Cmd->Size * sizeof(u32)) >
+					AllocatedBuffSize) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendBlockSet32(DevInst, Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_BlockWrite32Hdr) +
+				Cmd->Size * sizeof(u32);
+			BuffSize += (u32)sizeof(XAie_BlockWrite32Hdr) +
+				Cmd->Size * (u32)sizeof(u32);
+			continue;
+		}
+		else if(Cmd->Opcode == XAIE_IO_NOOP)
+		{
+			while( (BuffSize + sizeof(XAie_NoOpHdr)) >
+					AllocatedBuffSize ) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendNoOp(Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_NoOpHdr);
+			BuffSize += (u32)sizeof(XAie_NoOpHdr);
+			continue;
+		}
+		else if(Cmd->Opcode == XAIE_IO_PREEMPT)
+		{
+			while( (BuffSize + sizeof(XAie_PreemptHdr)) >
+					AllocatedBuffSize ) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendPreempt(Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_PreemptHdr);
+			BuffSize += (u32)sizeof(XAie_PreemptHdr);
+			continue;
+		}
+		else if(Cmd->Opcode == XAIE_IO_LOADPDI)
+		{
+			while( (BuffSize + sizeof(XAie_LoadPdiHdr)) >
+					AllocatedBuffSize ) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendLoadPdi(Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_LoadPdiHdr);
+			BuffSize += (u32)sizeof(XAie_LoadPdiHdr);
+			continue;
+		}
+		else if(Cmd->Opcode == XAIE_IO_LOAD_PM_START)
+		{
+			while( (BuffSize + sizeof(XAie_PmLoadHdr)) >
+					AllocatedBuffSize ) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			LoadSeqCountPtr = _XAie_AppendPmLoad(Cmd, TxnPtr, &LoadSeqCountOffset);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			LoadSeqCountOffset += BuffSize;
+			TxnPtr += sizeof(XAie_PmLoadHdr);
+			BuffSize += (u32)sizeof(XAie_PmLoadHdr);
+			DevInst->PmLoadingActive = 1;
+			continue;
+		}
+		else if (Cmd->Opcode == XAIE_IO_LOAD_PM_END_INTERNAL)
+		{
+			// Check if LoadSeqCountPtr needs to be updated due to realloc of TXN Ptr.
+			if ((LoadSeqCountOffset != 0) && (LoadSeqCountPtr != (TxnBasePtr + LoadSeqCountOffset))) {
+				LoadSeqCountPtr = TxnBasePtr + LoadSeqCountOffset;
+			}
+
+			if((LoadSeqCount != 0) && (LoadSeqCountPtr != NULL))
+			{
+				*LoadSeqCountPtr = LoadSeqCount & 0xFF;
+				*(LoadSeqCountPtr + 1) = (LoadSeqCount & 0xFF00) >> 8;
+				*(LoadSeqCountPtr + 2) = (LoadSeqCount & 0xFF0000) >> 16;
+			}
+			else if (LoadSeqCountPtr == NULL)
+			{
+				XAIE_ERROR("LoadSeqCountPtr is equal to NULL\n");
+				free(BlockwriteBuffer);
+				// To free Txn Buffer successfully we need to use the start pointer not current pointer
+				free(TxnBasePtr);
+				return NULL;
+			}
+			LoadSeqCount = 0;
+			NumOps--;
+			DevInst->PmLoadingActive = 0;
+			XAIE_TXN_EXPORT_MAP_NO_OPERATION(i);
+			continue;
+		}
+		else if(Cmd->Opcode == XAIE_IO_CREATE_SCRATCHPAD)
+		{
+			while( (BuffSize + sizeof(XAie_CreateScratchpadHdr)) >
+					AllocatedBuffSize ) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendCreateScratchpad(Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_CreateScratchpadHdr);
+			BuffSize += (u32)sizeof(XAie_CreateScratchpadHdr);
+			continue;
+		}
+		else if(Cmd->Opcode == XAIE_IO_UPDATE_STATE_TABLE)
+		{
+			while((BuffSize + sizeof(XAie_UpdateStateHdr)) >
+					AllocatedBuffSize ) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendUpdateState(Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_UpdateStateHdr);
+			BuffSize += (u32)sizeof(XAie_UpdateStateHdr);
+			continue;
+		}
+		else if(Cmd->Opcode == XAIE_IO_UPDATE_REG)
+		{
+			XAIE_TXN_EXPORT_MAP_BEFORE_UPDATE_REG(NumOps);
+			/* Check for 16KB boundary crossing and add padding if needed */
+			TxnPtr = _XAie_HandleTxnCmd16KBBoundary(TxnPtr, &BuffSize,
+								&AllocatedBuffSize, (u32)sizeof(XAie_UpdateRegHdr),
+								BlockwriteBuffer, &NumOps);
+			if (TxnPtr == NULL) {
+				return NULL;
+			}
+			while((BuffSize + sizeof(XAie_UpdateRegHdr)) >
+					AllocatedBuffSize ) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendUpdateReg(Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_UPDATE_REG(i, NumOps);
+			TxnPtr += sizeof(XAie_UpdateRegHdr);
+			BuffSize += (u32)sizeof(XAie_UpdateRegHdr);
+			continue;
+		}
+		else if(Cmd->Opcode == XAIE_IO_UPDATE_SCRATCH)
+		{
+			while( (BuffSize + sizeof(XAie_UpdateScratchHdr)) >
+					AllocatedBuffSize ) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendUpdateScratch(Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_COMMAND(i);
+			TxnPtr += sizeof(XAie_UpdateScratchHdr);
+			BuffSize += (u32)sizeof(XAie_UpdateScratchHdr);
+			continue;
+		}
+		else if (Cmd->Opcode >= XAIE_IO_CUSTOM_OP_TCT) {
+
+			if(Cmd->Opcode == XAIE_IO_CUSTOM_OP_DDR_PATCH)
+			{
+				++PatchCmdCount;
+			}
+			if (TX_DUMP_ENABLE) {
+				TxnCmdDump(Cmd);
+			}
+
+			XAIE_DBG("Size of the CustomOp Hdr being exported: %u bytes\n", sizeof(XAie_CustomOpHdr));
+
+			while((BuffSize + sizeof(XAie_CustomOpHdr) +
+						Cmd->Size) > AllocatedBuffSize) {
+				u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						AllocatedBuffSize * 2U, BuffSize);
+				if(TmpPtr == NULL) {
+					XAIE_ERROR("TxnPtr realloc failed\n");
+					free(BlockwriteBuffer);
+					free(TxnBasePtr);
+					return NULL;
+				}
+				TxnBasePtr = TmpPtr;
+				AllocatedBuffSize *= 2U;
+				TxnPtr = TxnBasePtr + BuffSize;
+			}
+			_XAie_AppendCustomOp(Cmd, TxnPtr);
+			XAIE_TXN_EXPORT_MAP_CUSTOM_COMMAND(Cmd, i);
+			TxnPtr += sizeof(XAie_CustomOpHdr) +
+				Cmd->Size * sizeof(u8);
+			BuffSize += (u32)sizeof(XAie_CustomOpHdr) +
+				Cmd->Size * (u32)sizeof(u8);
+			continue;
+		}
+		XAIE_TXN_EXPORT_MAP_UNHANDLED_COMMAND(Cmd, i);
+	}
+	if(FirstBlockwriteProcessed != 0)
+	{
+		XAIE_TXN_EXPORT_MAP_FLUSH_BLOCKWRITES(TmpInst, TmpInst->NumCmds);
+		XAie_BlockWrite32Hdr *Hdr = (XAie_BlockWrite32Hdr*)(uintptr_t)BlockwriteBuffer;
+		while((BuffSize + Hdr->Size) > AllocatedBuffSize) {
+			u8 *TmpPtr = _XAie_ReallocTxnBuf_MemInit(TxnBasePtr,
+						(AllocatedBuffSize) * 2U, BuffSize);
+			if(TmpPtr == NULL) {
+				XAIE_ERROR("TxnPtr realloc failed\n");
+				free(BlockwriteBuffer);
+				free(TxnBasePtr);
+				return NULL;
+			}
+			TxnBasePtr = TmpPtr;
+			AllocatedBuffSize *= 2U;
+			TxnPtr = TxnBasePtr + BuffSize;
+		}
+		BuffSize += Hdr->Size;
+		TxnPtr += _XAie_AppendBWToTxnBuff(BlockwriteBuffer,TxnPtr,PatchCmdCount);
+	}
+
+	XAIE_TXN_EXPORT_MAP_FINALIZE(TmpInst, NumOps, BlockwriteBuffer, TxnBasePtr);
+
+	// Free the BlockwriteBuffer
+	free(BlockwriteBuffer);
+
+	u32 four_byte_aligned_BuffSize = ((BuffSize % 4U) != 0U) ? ((BuffSize / 4U + 1U)*4) : BuffSize;
+	XAIE_DBG("Size of the Txn Hdr being exported: %u bytes\n",
+			sizeof(XAie_TxnHeader));
+	XAIE_DBG("Size of the transaction buffer being exported: %u bytes\n",
+			four_byte_aligned_BuffSize);
+	XAIE_DBG("Num of Operations in the transaction buffer: %u\n",
+			TmpInst->NumCmds);
+
+	/* Adjust pointer and reallocate to the right size */
+	u8 *NewPtr = _XAie_ReallocTxnBuf(TxnBasePtr, four_byte_aligned_BuffSize);
+	if(NewPtr == NULL) {
+		XAIE_ERROR("TxnPtr realloc failed\n");
+		free(TxnBasePtr);  /* Free original buffer on failure */
+		return NULL;
+	}
+	TxnBasePtr = NewPtr;
+	((XAie_TxnHeader *)(uintptr_t)TxnBasePtr)->NumOps =  NumOps;
+	((XAie_TxnHeader *)(uintptr_t)TxnBasePtr)->TxnSize =  four_byte_aligned_BuffSize;
+
+	return (u8 *)TxnBasePtr;
+}


### PR DESCRIPTION
### Provenance

This is the second of two AIE-RT changes needed by the MLIR-AIE infrastructure modernization described in #25. It may be applied directly, without dependency on #25.

### Why

Recorded transaction commands and serialized operations are not one-to-one. Serialization can coalesce block writes, omit internal commands, and add padding, so consumers cannot reliably reconstruct the relationship from the finished transaction.

MLIR-AIE needs this mapping to preserve command metadata through serialization.

### Changes

* Add `XAie_ExportSerializedTransactionWithCmdOpMap()` to return the serialized operation index for each recorded command.
* Use `XAIE_TXN_CMD_NO_SERIALIZED_OP` for commands that emit no operation.
* Add `XAie_FreeTxnCmdOpMap()` for caller-owned mapping storage.
* Keep the existing exporter on a separate no-map path.

The ordinary and mapped exporters produce identical transaction bytes. Existing callers incur no mapping allocation or metadata work.

### Testing

* Built independently on `release/main_aig` with both VS2026 and GCC 14.2, treating warnings as errors.
* Covered coalescing, omitted commands, converted operations, generated padding, and map ownership.
* Verified byte-exact identity between ordinary and mapped exports.
* Passed sanitizer coverage for the new mappings.
* Passed the complete Windows MLIR-AIE test suites when combined with #25, with no unexpected failures.